### PR TITLE
Some sparse matrix support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
       fail-fast: false
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Can be disabled with optional argument to revert to old behaviour of storing/multiplying by a dense matrix.

Refactor to simplify matrix setup. Remove `update_schur_complement_arrays!()`, putting its functionality into `update_schur_complement!()` and call `update_schur_complement!()` from the `mpi_schur_complement()` constructor.

Add option to save a sparse `B` and do the `A^-1.B.y` operation as first `B.y` then application of `A^-1`. If `B` is sparse enough this might sometimes be quicker than multiplying by the dense `Ainv_dot_B`.