### PR TITLE
Fix permissions so that documentation deployment on PRs works

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
+      pull-requests: read
+      statuses: write
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest


### PR DESCRIPTION
See example at https://documenter.juliadocs.org/stable/man/hosting/#GitHub-Actions.